### PR TITLE
The patient and doctors names show up instead of their ID numbers

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -5,6 +5,7 @@ class AppointmentsController < ApplicationController
   def index
     @appointments = Appointment.all
     @doctors = Doctor.all
+    @patients = Patient.all
   end
 
   # GET /appointments/1
@@ -47,7 +48,7 @@ class AppointmentsController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
+    # # Use callbacks to share common setup or constraints between actions.
     def set_appointment
       @appointment = Appointment.find(params[:id])
     end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -1,4 +1,4 @@
 class Appointment < ApplicationRecord
-    # belongs_to :doctors
-    # belongs_to :patients
+    belongs_to :doctor
+    belongs_to :patient
 end

--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -16,8 +16,9 @@
   <tbody>
     <% @appointments.each do |appointment| %>
       <tr>
-        <td><%= appointment.patient_id %></td>
-        <td><%= appointment.doctor_id %></td>
+      
+        <td><%= appointment.patient.last_name %></td>
+        <td>Dr. <%= appointment.doctor.last_name %></td>
         <td><%= appointment.appt %></td>
         <td><%= link_to 'Details', appointment %></td>
         <td><%= link_to 'Edit', edit_appointment_path(appointment) %></td>


### PR DESCRIPTION
This will make the patient and doctors name show up instead of the ID number when creating an appointment.