### PR TITLE
Turned off military time for appointments

### DIFF
--- a/app/views/appointments/index.html.erb
+++ b/app/views/appointments/index.html.erb
@@ -19,7 +19,7 @@
       
         <td><%= appointment.patient.last_name %></td>
         <td>Dr. <%= appointment.doctor.last_name %></td>
-        <td><%= appointment.appt %></td>
+        <td><%= appointment.appt.strftime("%m/%d/%Y %I:%M%p") %></td>
         <td><%= link_to 'Details', appointment %></td>
         <td><%= link_to 'Edit', edit_appointment_path(appointment) %></td>
         </tr>
@@ -30,3 +30,5 @@
 <br>
 
 <%= link_to 'New Appointment', new_appointment_path %>
+
+


### PR DESCRIPTION
This will show scheduled appointment times in standard 12 hour format instead of the military time 24 hour format that it was originally for a more professional user friendly look